### PR TITLE
[AO-80B] Add video tutorial for Analytics provider

### DIFF
--- a/src/components/doc/providers/Adwords.jsx
+++ b/src/components/doc/providers/Adwords.jsx
@@ -3,7 +3,7 @@ import LoomIframe from "../../helpers/LoomIframe";
 
 const Adwords = () => {
   return (
-    <Space id="adwords-provider" direction="vertical" style={{ width: "100%" }}>
+    <Space id="adwords" direction="vertical" style={{ width: "100%" }}>
       <h2>Adwords</h2>
       <p>
         Para descargar un reporte es necesario seleccionar <i>recurso</i>,{" "}

--- a/src/components/doc/providers/Analytics.jsx
+++ b/src/components/doc/providers/Analytics.jsx
@@ -1,13 +1,18 @@
 import { Space } from "antd";
+import LoomIframe from "../../helpers/LoomIframe";
 
 const Analytics = () => {
   return (
-    <Space id="analytics-provider" direction="vertical">
+    <Space id="analytics" direction="vertical" style={{ width: "100%" }}>
       <h2>Analytics</h2>
       <p>
         Para descargar un reporte es necesario seleccionar al menos una{" "}
         <i>dimensión</i> y una <i>métrica</i>.
       </p>
+      <LoomIframe
+        title="analytics-example"
+        src="https://www.loom.com/embed/57d672a0cd1f4f48b8389fb119bcdfb8"
+      />
     </Space>
   );
 };

--- a/src/components/doc/providers/Bing.jsx
+++ b/src/components/doc/providers/Bing.jsx
@@ -3,7 +3,7 @@ import LoomIframe from "../../helpers/LoomIframe";
 
 const Bing = () => {
   return (
-    <Space id="bing-provider" direction="vertical" style={{ width: "100%" }}>
+    <Space id="bing" direction="vertical" style={{ width: "100%" }}>
       <h2>Bing</h2>
       <p>
         Para descargar un reporte es necesario seleccionar un <i>nivel</i> y una{" "}

--- a/src/components/doc/providers/Facebook.jsx
+++ b/src/components/doc/providers/Facebook.jsx
@@ -3,11 +3,7 @@ import LoomIframe from "../../helpers/LoomIframe";
 
 const Facebook = () => {
   return (
-    <Space
-      id="facebook-provider"
-      direction="vertical"
-      style={{ width: "100%" }}
-    >
+    <Space id="facebook" direction="vertical" style={{ width: "100%" }}>
       <h2>Facebook</h2>
       <p>
         Para descargar un reporte es necesario seleccionar al menos un{" "}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -7,10 +7,10 @@ const Sidebar = () => {
       <Link href="#about-pitagoras" title="Sobre Pitágoras" />
       <Link href="#first-steps" title="Primeros pasos" />
       <Link href="#providers" title="Proveedores">
-        <Link href="#adwords-provider" title="Adwords" />
-        <Link href="#analytics-provider" title="Analytics" />
-        <Link href="#facebook-provider" title="Facebook" />
-        <Link href="#bing-provider" title="Bing" />
+        <Link href="#adwords" title="Adwords" />
+        <Link href="#analytics" title="Analytics" />
+        <Link href="#facebook" title="Facebook" />
+        <Link href="#bing" title="Bing" />
       </Link>
       <Link href="#reports" title="Creación de reportes" />
       <Link href="#faqs" title="FAQs" />


### PR DESCRIPTION
## Problem description 
- It's necessary to add a video tutorial using Loom for Analytics provider


## Changes
- [Add video tutorial for Analytics component](https://github.com/epa-datos/pitagoras-doc/commit/9413fc2cdee2d13d48f2bb57e9ec1cb02f347a3b)

## Other changes
- [Update id's attributes for providers components](https://github.com/epa-datos/pitagoras-doc/commit/3df9f55796d6df9b41bbf9879510075ccf08d217)