### PR TITLE
[AO-104] Add documentation for TikTok provider

### DIFF
--- a/src/components/doc/providers/AllProviders.jsx
+++ b/src/components/doc/providers/AllProviders.jsx
@@ -3,6 +3,7 @@ import Adwords from "./Adwords";
 import Analytics from "./Analytics";
 import Bing from "./Bing";
 import Facebook from "./Facebook";
+import Tiktok from "./Tiktok";
 import "./_provider.scss";
 
 const AllProviders = () => {
@@ -13,6 +14,7 @@ const AllProviders = () => {
       <Analytics />
       <Facebook />
       <Bing />
+      <Tiktok />
     </Space>
   );
 };

--- a/src/components/doc/providers/Tiktok.jsx
+++ b/src/components/doc/providers/Tiktok.jsx
@@ -1,0 +1,80 @@
+import { Space } from "antd";
+import LoomIframe from "../../helpers/LoomIframe";
+
+const Tiktok = () => {
+  return (
+    <Space id="tiktok" direction="vertical" style={{ width: "100%" }}>
+      <h2>TikTok</h2>
+      <p>
+        Para descargar un reporte es necesario seleccionar al menos un{" "}
+        <i>nivel de datos</i>, al menos una <i>dimensión</i> y una{" "}
+        <i>métrica.</i>
+      </p>
+
+      <LoomIframe
+        title="tiktok-example"
+        src="https://www.loom.com/embed/c347da7feef64fb2a2798dedaf3f7c66"
+      />
+      <p>
+        Para descargar un reporte evitando errores al comunicarse con la API de
+        TikTok es necesario tomar en cuenta las siguientes{" "}
+        <strong>consideraciones:</strong>
+      </p>
+      <ol>
+        <li>
+          Al seleccionar un nivel de datos (cuenta, campaña, adgroup o anuncio)
+          se necesita seleccionar la dimensión de ID correspondiente a ese
+          nivel. <br />
+          <i>
+            Ejemplo: Si se selecciona el nivel de datos{" "}
+            <strong>AUCTION_AD</strong> es necesario seleccionar la dimensión de{" "}
+            <strong>ad_id</strong>.
+          </i>
+        </li>
+        <li>
+          Existen dimensiones de tipo ID (<strong>advertiser_id</strong>,{" "}
+          <strong>campaign_id</strong>, <strong>adgroup_id</strong>,{" "}
+          <strong>ad_id</strong>) y de tipo tiempo (
+          <strong>stat_time_day</strong>, <strong>stat_time_hour</strong>), a lo
+          máximo se pueden seleccionar una dimensión de cada tipo.
+        </li>
+        <li>
+          La dimensión de <strong>country_code</strong> se puede usar siempre y
+          cuando no se seleccione otra dimensión, es decir, no puede combinarse
+          con más dimensiones.
+        </li>
+        <li>
+          Si se selecciona la dimensión de <strong>stat_time_day</strong> el
+          periodo de tiempo que se podrá consultar es de 30 días cómo máximo.
+        </li>
+        <li>
+          Si se selecciona la dimensión de <strong>stat_time_hour</strong> el
+          periodo de tiempo que se podrá consultar es de 1 día cómo máximo.
+        </li>
+        <li>
+          Se debe seleccionar al menos una métrica del grupo{" "}
+          <i>Basic Data Metrics</i>.
+        </li>
+        <li>
+          No se puede consultar una métrica que ya se esta incluyendo como
+          dimensión. Si lo que se requiere es agrupar la información, el dato en
+          cuestión se selecciona como dimensión, de lo contrario, se selecciona
+          como métrica.
+        </li>
+        <li>
+          Al seleccionar métricas de identidad (<strong>campaign_name</strong>,{" "}
+          <strong>adgroup_name</strong>, <strong>ad_name</strong>,{" "}
+          <strong>advertiser_name</strong>) es necesario seleccionar un nivel de
+          datos jerárquicamente igual o inferior a la métrica requerida.
+          <br />
+          <i>
+            Ejemplo: Para obtener la métrica de <strong>ad_name</strong> es
+            necesario seleccionar el nivel de datos <strong>AUCTION_AD</strong>.
+          </i>
+        </li>
+      </ol>
+    </Space>
+  );
+};
+
+export default Tiktok;

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -11,6 +11,7 @@ const Sidebar = () => {
         <Link href="#analytics" title="Analytics" />
         <Link href="#facebook" title="Facebook" />
         <Link href="#bing" title="Bing" />
+        <Link href="#tiktok" title="Tiktok" />
       </Link>
       <Link href="#faqs" title="FAQs" />
     </Anchor>


### PR DESCRIPTION
## Problem description
- After including TikTok as provider in the new version of Pitágoras add-on its necessary to include the documentation in this project. 

## Changes
- [Add **Tiktok** component with its corresponding doc](https://github.com/epa-datos/pitagoras-doc/commit/f259a0d0c3a0e9aebe789d7fbc121dd05753c712)
- [Add access to TikTok doc from **Sidebar** component](https://github.com/epa-datos/pitagoras-doc/commit/d15467e9823cf5ffaec7b233a3236a36caa4e4e3)

## More details
<img width="1502" alt="Screen Shot 2022-12-19 at 16 38 33" src="https://user-images.githubusercontent.com/38545126/208540384-4d732735-0c9a-4f0e-b1e2-d85a7cc4bc5c.png">
